### PR TITLE
Allow for lodash 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "pegjs":                "0.10.0",
-        "lodash":               "4.17.11",
+        "lodash":               "^4.17.11",
         "static-module":        "3.0.3",
         "through":              "2.3.8"
     }


### PR DESCRIPTION
lodash 4.17.11 has a security advisory and pegging a particular version is too strict: https://www.npmjs.com/advisories/1065