### PR TITLE
[fix] Depend directly on lodash.assignin

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,11 +29,11 @@
 var fs      = require("fs");
 
 /*  external requirements  */
-var _       = require("lodash");
+var extend       = require("lodash.assignin");
 var pegjs   = require("pegjs");
 
 /*  provide a minimum wrapper class around PEG.js API  */
-module.exports = _.extend({
+module.exports = extend({
 	/*  provide an additional method which is like "generate",
 	    but gets a grammar filename instead of the grammar text  */
     generateFromFile: function (filename, options) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "pegjs":                "0.10.0",
-        "lodash":               "4.17.14",
+        "lodash.assignin":      "4.2.0",
         "static-module":        "3.0.3",
         "through":              "2.3.8"
     }


### PR DESCRIPTION
When bundling, this will help ensure a more minimal bundle size rather than assuming there will be tree-shaking to get eject the unused portions of lodash.